### PR TITLE
Add require on subr-x

### DIFF
--- a/anki-vocabulary.el
+++ b/anki-vocabulary.el
@@ -40,6 +40,7 @@
 
 (require 's)
 (require 'cl-lib)
+(require 'subr-x)
 (require 'youdao-dictionary)
 (require 'anki-connect)
 (declare-function pdf-view-active-region-text "ext:pdf-view" ())


### PR DESCRIPTION
Fixes:
```
anki-vocabulary.el:266:1:Warning: the function `string-join' is not known to
be defined.
```
re: https://github.com/melpa/melpa/pull/6559