### PR TITLE
Update anki-vocabulary.el

### DIFF
--- a/anki-vocabulary.el
+++ b/anki-vocabulary.el
@@ -44,7 +44,7 @@
 (require 'youdao-dictionary)
 (require 'anki-connect)
 (declare-function pdf-view-active-region-text "ext:pdf-view" ())
-(declare-function pdf-view-assert-active-region "ext:pdf-view" () t)
+(declare-function pdf-view-assert-active-region "ext:pdf-view" ())
 
 
 (defgroup anki-vocabulary nil


### PR DESCRIPTION
Fix the issue `pdf-view-assert-active-region` macro doesn't byte-compiled correctly.
Loading the incorrectly byte-compiled file will cause the error when use `anki-vocabulary` in pdf-view-mode :
```
anki-vocabulary--get-pdf-text: Invalid function: pdf-view-assert-active-region
```